### PR TITLE
Resource is null right after helm upgrade. Return undefined/null until data is available.

### DIFF
--- a/frontend/packages/helm-plugin/src/actions/providers.ts
+++ b/frontend/packages/helm-plugin/src/actions/providers.ts
@@ -30,10 +30,12 @@ export const useHelmActionProviderForTopology = (element: GraphElement) => {
     const nodeType = element.getType();
     if (nodeType !== TYPE_HELM_RELEASE) return undefined;
     const releaseName = element.getLabel();
+    const resource = getResource(element);
+    if (!resource?.metadata) return null;
     const {
       namespace,
       labels: { version },
-    } = getResource(element).metadata;
+    } = resource.metadata;
     return {
       release: {
         name: releaseName,

--- a/frontend/packages/helm-plugin/src/topology/sidebar/release-panel/resource-link.tsx
+++ b/frontend/packages/helm-plugin/src/topology/sidebar/release-panel/resource-link.tsx
@@ -8,7 +8,9 @@ import { TYPE_HELM_RELEASE } from '../../components/const';
 const helmReleasePanelResourceLink = (element: GraphElement) => {
   if (element.getType() !== TYPE_HELM_RELEASE) return undefined;
   const name = element.getLabel();
-  const { namespace } = getResource(element).metadata;
+  const resource = getResource(element);
+  if (!resource?.metadata) return null;
+  const { namespace } = resource.metadata;
   return (
     <>
       <ResourceIcon className="co-m-resource-icon--lg" kind="HelmRelease" />

--- a/frontend/packages/helm-plugin/src/topology/sidebar/release-panel/tab-sections.tsx
+++ b/frontend/packages/helm-plugin/src/topology/sidebar/release-panel/tab-sections.tsx
@@ -36,16 +36,18 @@ export const getHelmReleasePanelDetailsTabSection = (element: GraphElement) => {
 export const getHelmReleasePanelResourceTabSection = (element: GraphElement) => {
   if (element.getType() !== TYPE_HELM_RELEASE) return undefined;
   const { manifestResources } = element.getData().data;
-  const { namespace } = getResource(element).metadata;
+  const resource = getResource(element);
+  if (!manifestResources || !resource?.metadata) return null;
+  const { namespace } = resource.metadata;
 
-  return manifestResources ? (
+  return (
     <div className="overview__sidebar-pane-body">
       <TopologyGroupResourcesPanel
         manifestResources={manifestResources}
         releaseNamespace={namespace}
       />
     </div>
-  ) : null;
+  );
 };
 
 export const getHelmReleasePanelReleaseNotesTabSection = (element: GraphElement) => {


### PR DESCRIPTION
Fix for failing cypress tests of https://github.com/openshift/console/pull/10812

See https://prow.ci.openshift.org/pr-history/?org=openshift&repo=console&pr=10812

This happens when upgrading a helm release and selecting it quickly in topology. Maybe this happens more even more because if your performance/data usage improvements. But it looks like an general issue which happen also in the past, see:

https://search.ci.openshift.org/?search=StaleElementReferenceError%3A+stale+element+reference%3A+element+is+not+attached+to+the+page+document&maxAge=336h&context=0&type=all&name=pull-ci-openshift-console-master-e2e-gcp-console&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

Could reproduce this in dev mode as well when running the cypress tests locally.